### PR TITLE
goreleaser config: mark /etc/default/tigrisfs as 0600

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,9 @@ nfpms:
         dst: /lib/systemd/user/tigrisfs@.service
       - src: pkg/defaults
         dst: /etc/default/tigrisfs
+        type: "config|noreplace"
+        file_info:
+          mode: 0600
     scripts:
       postinstall: pkg/postinst
 


### PR DESCRIPTION
Otherwise it defaults to 0644, which could let malicious programs running in unprivileged user contexts access Tigris with the same permissions as the machine running tigrisfs.