### PR TITLE
feat(performance): Preload small file on directory list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In the first release we focused on improving security and reliability of the cod
 
 When mounted with the [Tigris](https://www.tigrisdata.com) backend TigrisFS supports:
   * POSIX permissions, special files, symbolic links.
+  * Auto-preload content of small files on directory list in single request.
   * Allows to auto prefetch directory data to the region on list.
 
 # Installation

--- a/core/handles.go
+++ b/core/handles.go
@@ -227,6 +227,9 @@ func (inode *Inode) SetFromBlobItem(item *BlobItemOutput) {
 			inode.setMetadata(item.Metadata)
 			inode.userMetadataDirty = 0
 		}
+		if item.Content != nil {
+			inode.buffers.Add(0, item.Content, BUF_CLEAN, false)
+		}
 	}
 	if item.ETag != nil {
 		inode.s3Metadata["etag"] = []byte(*item.ETag)

--- a/main.go
+++ b/main.go
@@ -114,6 +114,8 @@ func main() {
 
 		cfg.InitLoggers(flags)
 
+		mainLog.Debug().Interface("flags", flags).Msg("config")
+
 		mainLog.Info().Str("version", cfg.Version).Msg("Starting TigrisFS version")
 		mainLog.Info().Str("bucketName", bucketName).Str("mountPoint", flags.MountPoint).Msg("Mounting")
 		mainLog.Info().Uint32("uid", flags.Uid).Uint32("defaultGid", flags.Gid).Msg("Default uid=gid")

--- a/test/cases/tigris_list_content.sh
+++ b/test/cases/tigris_list_content.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2025 Tigris Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+. "$(dirname "$0")/../mount.sh"
+
+CASE=list_content
+
+DIR="$MNT_DIR/$CASE/$RANDOM"
+mkdir -p "$DIR"
+fn="$DIR/file"
+
+NUM_FILES=999
+
+set +x
+for i in $(seq $NUM_FILES); do
+  echo "test $i" > "$fn.$i"
+done
+set -x
+
+# Drop caches by remounting
+_umount "$MNT_DIR"
+# shellcheck disable=SC2086
+FS_BIN=$(dirname "$0")/../../tigrisfs _mount "$MNT_DIR" $DEF_MNT_PARAMS --tigris-list-content
+sleep 5
+
+start=$(date +%s%3N)
+# Test list content
+ls -la "$DIR" | grep -E "file.[0-9]{1,3}" | wc -l | grep $NUM_FILES
+
+set +x
+for i in $(seq $NUM_FILES); do
+  grep -e "test $i" "$fn.$i" || exit 1
+done
+set -x
+end=$(date +%s%3N)
+echo "Duration: $((end - start)) ms"
+
+# Create new set of files
+DIR="$MNT_DIR/$CASE/no-preload/$RANDOM"
+mkdir -p "$DIR"
+fn="$DIR/file"
+
+set +x
+for i in $(seq $NUM_FILES); do
+  echo "test $i" > "$fn.$i"
+done
+set -x
+
+# Drop caches by remounting and not set --tigris-list-content
+_umount "$MNT_DIR"
+# shellcheck disable=SC2086
+FS_BIN=$(dirname "$0")/../../tigrisfs _mount "$MNT_DIR" $DEF_MNT_PARAMS
+sleep 5
+
+start=$(date +%s%3N)
+# Test list content
+ls -la "$DIR" | grep -E "file.[0-9]{1,3}" | wc -l | grep $NUM_FILES
+
+set +x
+for i in $(seq $NUM_FILES); do
+  grep -e "test $i" "$fn.$i" || exit 1
+done
+set -x
+end=$(date +%s%3N)
+echo "Duration: $((end - start)) ms"

--- a/test/cases/tigris_posix_meta.sh
+++ b/test/cases/tigris_posix_meta.sh
@@ -48,7 +48,8 @@ chmod 600 "${fn}_fifo"
 
 # Test attributes persisted after restart
 _umount "$MNT_DIR"
-FS_BIN=$(dirname "$0")/../../tigrisfs _mount "$MNT_DIR" --enable-specials --enable-perms
+# shellcheck disable=SC2086
+FS_BIN=$(dirname "$0")/../../tigrisfs _mount "$MNT_DIR" $DEF_MNT_PARAMS
 sleep 5
 
 [ "$(stat -c '%G' $fn)" == "users" ] || exit 1

--- a/test/run-cases.sh
+++ b/test/run-cases.sh
@@ -12,7 +12,9 @@ export ENDPOINT=${ENDPOINT:-"http://localhost:8080"}
 
 _s3cmd mb s3://$BUCKET_NAME
 
-_mount "$MNT_DIR" --enable-specials --enable-perms
+export DEF_MNT_PARAMS="--enable-mtime --enable-specials --enable-perms"
+# shellcheck disable=SC2086
+_mount "$MNT_DIR" $DEF_MNT_PARAMS
 trap '_umount $MNT_DIR' EXIT
 
 sleep 5


### PR DESCRIPTION
Preload small files of the directory into cache in single list object request. Enable by: `--tigris-list-content`

In local test loading 1000 files twice as fast.