### PR TITLE
chore: fix mount directory names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ See [docs](https://www.tigrisdata.com/docs/sdks/s3/aws-cli/) for more details.
     ```bash
     systemctl --user start tigrisfs@<bucket>
     ```
-    The bucket is mounted at `$HOME/mnt/tigrisfs/<bucket>`.
+    The bucket is mounted at `$HOME/mnt/tigris/<bucket>`.
   * as root
     ```bash
     systemctl start tigrisfs@<bucket>
     ```
-    The bucket is mounted at `/mnt/tigrisfs/<bucket>`.
+    The bucket is mounted at `/mnt/tigris/<bucket>`.
 
 ## Binary install
 


### PR DESCRIPTION
For both user and root services, the correct base directory is `/mnt/tigris/`:
https://github.com/tigrisdata/tigrisfs/blob/b4a26b5c712118539bc1df5994ab79711d9b10eb/pkg/tigrisfs%40.service#L10-L11
https://github.com/tigrisdata/tigrisfs/blob/b4a26b5c712118539bc1df5994ab79711d9b10eb/pkg/tigrisfs_user%40.service#L10-L11