### PR TITLE
fix: Potential fix for #37 Mount locks up on listing bucket

### DIFF
--- a/core/dir.go
+++ b/core/dir.go
@@ -622,7 +622,9 @@ func (dh *DirHandle) listObjectsFlat() (start string, err error) {
 			dh.inode.dir.listMarker = lastName
 		}
 	} else {
+		dh.mu.Unlock()
 		dh.inode.sealDir()
+		dh.mu.Lock()
 	}
 
 	dh.inode.mu.Unlock()


### PR DESCRIPTION
`(inode *Inode) sealDir()` may try to lock the parent via
- `(parent *Inode) removeExpired(from string)`
- `(parent *Inode) removeChildUnlocked(inode *Inode)` at
```
	for _, dh := range parent.dir.handles {
		dh.mu.Lock()
		dh.lastInternalOffset = -1
		dh.mu.Unlock()
	}
```

So, unlock the parent up front in order to avoid a dead-lock.

Caveat: I am not deep enough into the code to say this won't create other problems.