### PR TITLE
chore: add docker-build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 goofys
-.git

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,18 @@
+name: docker-build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@main
+    - name: build application
+      run: make docker-build
+    - name: check dist
+      run: ls -l dist/ && file dist/tigrisfs
+

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo
-      uses: actions/checkout@main
+      uses: actions/checkout@v5
     - name: build application
       run: make docker-build
     - name: check dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest AS build
+
+RUN apt-get update && apt-get install -y git make wget curl sudo unzip golang shellcheck s3cmd util-linux fuse3
+
+COPY --link . /src
+
+WORKDIR /src
+
+ENV CGO_ENABLED=0
+
+RUN make setup
+RUN make build
+
+FROM scratch
+COPY --from=build /src/tigrisfs /

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ get-deps: s3proxy.jar
 build:
 	go build $(BUILD_PARAM)
 
+.PHONY: docker-build
+docker-build:
+	docker build --output dist .
+
 build-debug:
 	CGO_ENABLED=1 go build -race $(BUILD_PARAM)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigrisdata/tigrisfs
 
-go 1.24
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.51.0


### PR DESCRIPTION
This adds a Dockerfile and Makefile rule to build the code in Docker (on non-Ubuntu hosts). The built binary will be placed in dist/tigrisfs.

This also removes `.git` from `.dockerignore` because `git describe` is needed in the build process inside the container to determine the version label.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Dockerfile and Makefile target to build binary in Docker and a CI workflow to run it, plus minor .dockerignore and Go version tweaks.
> 
> - **Build/CI**:
>   - **Dockerfile**: Multi-stage build on `ubuntu:latest`; runs `make setup` and `make build`; outputs static binary to `scratch` image.
>   - **Makefile**: Add `docker-build` target (and `.PHONY`) to produce `dist/` via `docker build --output dist .`.
>   - **GitHub Actions**: New workflow at `.github/workflows/docker-build.yaml` builds on `push` to `main` and verifies `dist/tigrisfs`.
> - **Housekeeping**:
>   - `.dockerignore`: remove `.git` to allow versioning metadata; keep `goofys`.
>   - `go.mod`: bump `go` to `1.24.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce42618a56f26733edc15e435aabff9930fa896f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->