### PR TITLE
fix: Prevent removals based on stale inode pointers

### DIFF
--- a/core/goofys.go
+++ b/core/goofys.go
@@ -958,7 +958,10 @@ func (fs *Goofys) RefreshInodeCache(inode *Inode) error {
 		}
 		return mappedErr
 	}
-	_, err := parent.recheckInode(inode, name)
+	// Use recheckInodeByName to ensure we work with the current child instance
+	// This handles cases where the inode passed to RefreshInodeCache might be
+	// a stale reference from fs.inodes while parent.dir.Children has a newer instance
+	_, err := parent.recheckInodeByName(name)
 	mappedErr = mapAwsError(err)
 	if mappedErr == syscall.ENOENT {
 		notifications = append(notifications, &fuseops.NotifyDelete{


### PR DESCRIPTION
The issue occurs in recheckInode when attempting to remove a stale inode.

The problem was that recheckInode was calling removeChild with the inode instance
passed to it, but due to concurrent operations or cache updates, this might not
be the same instance that's currently in the parent's children list. 

Fixes the test failure seen in CI where:
```
goofys_unix_test.go:585:
    t.Assert(os.IsNotExist(err), Equals, true)
... obtained bool = false
... expected bool = true
```

🤖 Generated with [Claude Code](https://claude.ai/code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `Inode.recheckInodeByName` and update `RefreshInodeCache` to use it, preventing removals based on stale inode pointers.
> 
> - **Core**:
>   - **Stale inode handling**:
>     - Add `Inode.recheckInodeByName` in `core/dir.go` to look up the current child by `name` before rechecking, removing the actual current child on error.
>     - Update `core/goofys.go::RefreshInodeCache` to call `parent.recheckInodeByName(name)` instead of `recheckInode(inode, name)` to avoid acting on stale inode references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b42fe95b1b114ca4ab526b017cb8148492d2fbf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->