### PR TITLE
fix: Resolve deadlock in listObjectsSlurp directory sealing

### DIFF
--- a/core/dir.go
+++ b/core/dir.go
@@ -296,6 +296,7 @@ func (parent *Inode) sealChildDirectories(dirs map[*Inode]bool, resp *ListBlobsO
 			if atomic.LoadUint64(&child.dir.generation) != gen+1 {
 				// Seal failed validation - directory was modified concurrently
 				// This should not happen since we hold child.mu, but be defensive
+				fuseLog.Debugf("Seal failed validation for directory %v: generation=%v expected=%v", child.FullName(), atomic.LoadUint64(&child.dir.generation), gen+1)
 			}
 		}
 		child.mu.Unlock()
@@ -435,8 +436,8 @@ func (parent *Inode) listObjectsSlurp(inode *Inode, startAfter string, sealEnd b
 			sealSucceeded = parent.sealDirWithValidation()
 			alreadySealed = !sealSucceeded && parent.dir.listDone
 
-			// Special case: if already sealed but got items, update mtime (lock=true only)
-			if alreadySealed && hasItems && lock {
+			// Special case: if already sealed but got items, update mtime
+			if alreadySealed && hasItems {
 				parent.updateDirectoryMtime()
 			}
 

--- a/core/dir.go
+++ b/core/dir.go
@@ -357,20 +357,27 @@ func (parent *Inode) listObjectsSlurp(inode *Inode, startAfter string, sealEnd b
 				parentGen := atomic.LoadUint64(&parent.dir.generation)
 				parent.mu.Unlock()
 
-				// Seal the inode with its own lock
-				inode.mu.Lock()
-				inode.sealDir()
-				inode.mu.Unlock()
-
 				// Reacquire parent lock and verify parent hasn't changed
 				parent.mu.Lock()
 				if atomic.LoadUint64(&parent.dir.generation) == parentGen {
-					// Parent hasn't changed, safe to mark gap as loaded
-					parent.dir.markGapLoaded(NilStr(startWith), calculatedNextStartAfter)
-					// Gap marked successfully, signal completion
-					nextStartAfter = ""
+					// Parent hasn't changed, safe to seal inode and mark gap
+					parent.mu.Unlock()
+
+					inode.mu.Lock()
+					inode.sealDir()
+					inode.mu.Unlock()
+
+					parent.mu.Lock()
+					// Verify parent still hasn't changed after sealing
+					if atomic.LoadUint64(&parent.dir.generation) == parentGen {
+						parent.dir.markGapLoaded(NilStr(startWith), calculatedNextStartAfter)
+						nextStartAfter = ""
+					} else {
+						// Parent changed during seal, return partial progress
+						nextStartAfter = calculatedNextStartAfter
+					}
 				} else {
-					// Parent changed, gap not marked, return partial progress
+					// Parent changed, skip sealing and gap marking, return partial progress
 					nextStartAfter = calculatedNextStartAfter
 				}
 				parent.mu.Unlock()

--- a/core/dir.go
+++ b/core/dir.go
@@ -310,13 +310,7 @@ func (parent *Inode) listObjectsSlurp(inode *Inode, startAfter string, sealEnd b
 			child.mu.Lock()
 			// Capture generation and check if already sealed while holding the lock
 			if !child.dir.listDone {
-				gen := atomic.LoadUint64(&child.dir.generation)
 				child.sealDir()
-				// Verify seal succeeded (generation incremented by exactly 1)
-				if atomic.LoadUint64(&child.dir.generation) != gen+1 {
-					// Seal failed validation - directory was modified concurrently
-					// This should not happen since we hold child.mu, but be defensive
-				}
 			}
 			child.mu.Unlock()
 		}

--- a/core/dir.go
+++ b/core/dir.go
@@ -392,6 +392,11 @@ func (parent *Inode) listObjectsSlurp(inode *Inode, startAfter string, sealEnd b
 				inode.mu.Lock()
 				sealSucceeded = inode.sealDirWithValidation()
 				alreadySealed = !sealSucceeded && inode.dir.listDone
+
+				// Special case: if already sealed but got items, update mtime
+				if alreadySealed && hasItems {
+					inode.updateDirectoryMtime()
+				}
 				inode.mu.Unlock()
 
 				// Reacquire parent lock and validate generation
@@ -410,6 +415,11 @@ func (parent *Inode) listObjectsSlurp(inode *Inode, startAfter string, sealEnd b
 				inode.mu.Lock()
 				sealSucceeded = inode.sealDirWithValidation()
 				alreadySealed = !sealSucceeded && inode.dir.listDone
+
+				// Special case: if already sealed but got items, update mtime
+				if alreadySealed && hasItems {
+					inode.updateDirectoryMtime()
+				}
 				inode.mu.Unlock()
 
 				// Validate parent generation before marking gap


### PR DESCRIPTION
## Summary

This PR fixes deadlocks in the `listObjectsSlurp()` function where lock ordering violations occurred when sealing child directories.

## Problem

The deadlock occurred in two places within `listObjectsSlurp()` at `core/dir.go:290-352`:

### 1. Child directory sealing loop
When `insertSubTree()` created child directory inodes and added them to the `dirs` map, the subsequent loop tried to lock these child inodes while holding `parent.mu`. This created circular lock dependencies with concurrent operations.

### 2. Target inode sealing  
When sealing the target inode while holding `parent.mu`, similar lock ordering issues could occur.

## Deadlock Scenarios

**Scenario 1 (stat/getattr blocking):**
```
Shell (tab completion) → fuse_getattr → waiting for FUSE response
tigrisfs thread → listObjectsSlurp → holds parent.mu → tries to lock children
Concurrent getattr → walks from root → circular dependency
```

Stack trace showed:
```
[<0>] fuse_do_getattr+0xf0/0x210
[<0>] fuse_update_get_attr+0x125/0x1b0
[<0>] fuse_getattr+0x8a/0xc0
```

**Scenario 2 (rename blocking):**
```  
borg → fuse_rename2 → waiting for FUSE response
tigrisfs thread → Rename → holds parent+fromInode locks → calls listObjectsSlurp(lock=false)
listObjectsSlurp → tries to lock child directories → circular dependency
```

Stack trace showed:
```
[<0>] fuse_rename_common+0x105/0x2f0
[<0>] fuse_rename2+0x83/0xc0
```

## Solution

Applied the generation-based approach from PR #43 to `listObjectsSlurp`:

### For child directory sealing:
1. Capture generation counters before releasing `parent.mu`
2. Release `parent.mu` before locking and sealing children
3. Check generation after acquiring child lock - skip if changed
4. Only perform this when `lock=true` (when `lock=false`, caller handles ordering)

### For target inode sealing:
1. Capture generation before releasing `parent.mu`
2. Release `parent.mu`, acquire `inode.mu` separately
3. Check generation - skip sealing if changed
4. Handle `lock=false` case where caller holds locks

This prevents holding multiple inode locks simultaneously while maintaining correctness through generation tracking. If the directory structure changes while we don't hold locks, we skip sealing since whoever made the change will handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors directory sealing to avoid holding multiple inode locks by unlocking parent before sealing children and validating via generation counters, with adjusted mtime/gap updates and lock=false handling.
> 
> - **core/dir.go**:
>   - **New helpers**: `sealDirWithValidation`, `updateDirectoryMtime`, and `sealChildDirectories` to validate generation increments, update mtimes from children, and seal child dirs without holding `parent.mu`.
>   - **listObjectsSlurp**:
>     - Seals child directories outside `parent.mu` using `sealChildDirectories` and per-child generation validation.
>     - Reworks target inode sealing: releases/reacquires locks, validates generations, and updates `nextStartAfter`/`markGapLoaded` conditionally based on `lock` and seal outcome; updates mtime if already sealed but items arrived.
>     - Computes `nextStartAfter` before sealing and adjusts control flow to return early on seal vs. continue with pagination.
>   - **Minor**: small generation/mtime handling helpers used during sealing; whitespace/comments tidy-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f924d13c33a6eba1c86c3fedbf705da2f32c465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->