### PR TITLE
fix: prevent Rename self-deadlock in isEmptyDir cold-cache listing

### DIFF
--- a/core/dir.go
+++ b/core/dir.go
@@ -404,10 +404,10 @@ func (inode *Inode) sealDir() {
 	} else {
 		inode.Attributes.Mtime, inode.Attributes.Ctime = inode.findChildMaxTime()
 	}
-	
+
 	// Increment generation to signal all handles need revalidation
 	atomic.AddUint64(&inode.dir.generation, 1)
-	
+
 	inode.removeExpired("")
 }
 
@@ -660,7 +660,7 @@ func (dh *DirHandle) checkDirPosition() {
 		dh.lastInternalOffset = -1
 		dh.generation = currentGen
 	}
-	
+
 	if dh.lastInternalOffset < 0 {
 		parent := dh.inode
 		// Directory position invalidated, try to find it again using lastName
@@ -1047,10 +1047,10 @@ func (parent *Inode) removeChildUnlocked(inode *Inode) {
 	if l == 0 {
 		return
 	}
-	
+
 	// Increment generation to invalidate all directory handles
 	atomic.AddUint64(&parent.dir.generation, 1)
-	
+
 	i := sort.Search(l, parent.findInodeFunc(inode.Name))
 	if i >= l || parent.dir.Children[i].Name != inode.Name {
 		panic(fmt.Sprintf("%v.removeName(%v) but child not found: %v",
@@ -1493,13 +1493,97 @@ func appendChildName(parent, child string) string {
 	return parent + child
 }
 
-func (inode *Inode) isEmptyDir() (bool, error) {
-	dh := NewDirHandle(inode)
-	dh.mu.Lock()
-	dh.Seek(2)
-	en, err := dh.ReadDir()
-	dh.mu.Unlock()
-	return en == nil, err
+// isEmptyDirFast reports whether a directory has no live entries, for Rename's
+// overwrite check. It never goes through the listing path (loadListing → slurpOnce
+// → insertSubTree), which slurps from the ROOT and re-locks ancestor inodes — a
+// self-deadlock when Rename already holds the parent locks (proven by a goroutine
+// dump under an npm rename storm) — so it is safe to call under those locks. It
+// reconciles both sides of the cache the way the listing path does: live in-memory
+// children (covering local creates not yet flushed), a listDone+unexpired fast path,
+// and otherwise a prefix-scoped backend list (delimited, paged) that skips
+// locally-deleted names, followed by a re-check of the in-memory children to catch a
+// create that raced the list. The backend list runs WITHOUT inode.mu held (in
+// cluster mode it can be a cross-node RPC).
+// LOCKS_EXCLUDED(inode.mu) — safe with ancestor locks held.
+func (inode *Inode) isEmptyDirFast() (bool, error) {
+	// Local state first, under the inode lock. A live in-memory child covers a
+	// locally-created entry not yet flushed to the backend, which a listing would
+	// miss; ST_DEAD/ST_DELETED are gone. If the directory is fully listed AND that
+	// listing has not expired, the in-memory children are authoritative and no
+	// backend call is needed; a stale listDone can hide children the backend gained.
+	inode.mu.Lock()
+	if live := inode.hasLiveChild(); live || (inode.dir.listDone &&
+		!expired(inode.dir.DirTime, inode.fs.flags.StatCacheTTL)) {
+		inode.mu.Unlock()
+		return !live, nil
+	}
+	// Snapshot the local deletes and drop the lock BEFORE the backend list. The list
+	// must not run under inode.mu: in cluster mode it can be a cross-node RPC, and
+	// holding a FUSE inode lock across it deadlocks (and it is pointless latency in
+	// the single-node case). The list never walks the inode tree either, so there is
+	// no root slurp to re-lock Rename's held parent.
+	deleted := make(map[string]struct{}, len(inode.dir.DeletedChildren))
+	for name := range inode.dir.DeletedChildren {
+		deleted[name] = struct{}{}
+	}
+	inode.mu.Unlock()
+
+	// A delimiter collapses each subtree to one immediate-child prefix (so a deleted
+	// directory with many descendants counts as one name, not a page of keys), and we
+	// page to the first entry whose immediate name is NOT locally deleted. Only the
+	// pathological "many locally-deleted children, no live one yet" case pages past
+	// the first response.
+	cloud, key := inode.cloud()
+	prefix := key + "/"
+	var token *string
+	for {
+		resp, err := RetryListBlobs(inode.fs.flags, cloud, &ListBlobsInput{
+			Prefix:            PString(prefix),
+			Delimiter:         PString("/"),
+			MaxKeys:           PUInt32(1000),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return false, err
+		}
+		for i := range resp.Prefixes {
+			name := strings.TrimSuffix((*resp.Prefixes[i].Prefix)[len(prefix):], "/")
+			if _, del := deleted[name]; !del {
+				return false, nil
+			}
+		}
+		for i := range resp.Items {
+			k := *resp.Items[i].Key
+			if k == prefix {
+				continue // the directory's own marker object
+			}
+			if _, del := deleted[k[len(prefix):]]; !del {
+				return false, nil
+			}
+		}
+		if !resp.IsTruncated || resp.NextContinuationToken == nil {
+			break
+		}
+		token = resp.NextContinuationToken
+	}
+
+	// Re-check local children under the lock: a Create/MkDir into the target only
+	// needs inode.mu, so one may have landed while we were listing unlocked. This
+	// closes that window without ever holding the lock across the backend call.
+	inode.mu.Lock()
+	defer inode.mu.Unlock()
+	return !inode.hasLiveChild(), nil
+}
+
+// hasLiveChild reports whether any in-memory child is present (not ST_DEAD/ST_DELETED).
+// LOCKS_REQUIRED(inode.mu)
+func (inode *Inode) hasLiveChild() bool {
+	for _, c := range inode.dir.Children {
+		if s := atomic.LoadInt32(&c.CacheState); s != ST_DEAD && s != ST_DELETED {
+			return true
+		}
+	}
+	return false
 }
 
 // LOCKS_REQUIRED(inode.Parent.mu)
@@ -1655,7 +1739,11 @@ func (parent *Inode) Rename(from string, newParent *Inode, to string) (err error
 			if !toInode.isDir() {
 				return syscall.ENOTDIR
 			}
-			toEmpty, err := toInode.isEmptyDir()
+			// isEmptyDirFast checks under this held lock (race-free, like the original
+			// isEmptyDir) but never lists from the root, so it does not self-deadlock.
+			// It reconciles local cache state with the backend, so both unflushed
+			// local creates and pending local deletes are honored.
+			toEmpty, err := toInode.isEmptyDirFast()
 			if err != nil {
 				return err
 			}
@@ -2025,7 +2113,7 @@ func (parent *Inode) recheckInodeByName(name string) (newInode *Inode, err error
 	parent.mu.Lock()
 	currentChild := parent.findChildUnlocked(name)
 	parent.mu.Unlock()
-	
+
 	newInode, err = parent.LookUp(name, currentChild == nil && !parent.fs.flags.NoPreloadDir)
 	if err != nil {
 		if currentChild != nil {

--- a/core/goofys_test.go
+++ b/core/goofys_test.go
@@ -1194,6 +1194,81 @@ func (s *GoofysTest) TestBackendListPrefix(t *C) {
 	t.Assert(*res.Items[0].Key, Equals, "test_list_prefix/dir2/dir3/file4")
 }
 
+// Regression test for the Rename self-deadlock: renaming a directory onto an
+// existing EMPTY directory whose listing has expired made isEmptyDir() reload
+// the listing while Rename held the parent locks. With slurp enabled
+// (StatCacheTTL != 0 — the production default), that reload starts at the ROOT
+// (slurpOnce walks up) and insertSubTree re-locks every directory on the path
+// back down — including the very parent Rename already holds. Go mutexes are
+// not reentrant, so the daemon deadlocked and every later FUSE op queued behind
+// the held locks forever.
+//
+// TestRenameDir cannot catch this: it sets StatCacheTTL = 0, which disables the
+// slurp path entirely (loadListing's useSlurp condition). Reproducing it needs
+// three things together, all of which the live npm-install workload produced
+// via churn and all of which this test sets up explicitly:
+//  1. slurp enabled (StatCacheTTL != 0),
+//  2. a parent BELOW the root, so the root-down insertSubTree walk crosses it,
+//  3. the rename target's directory cache EXPIRED, so isEmptyDir re-lists
+//     instead of answering from cache (DirTime = zero == always expired — the
+//     same cold state a generation reset leaves behind).
+//
+// Without the fix this deadlocks (caught by the timeout); with the fix the
+// emptiness check runs lock-free before Rename takes its locks.
+func (s *GoofysTest) TestRenameDirColdTarget(t *C) {
+	// Slurp ON — the production default that TestRenameDir turns off.
+	s.fs.flags.StatCacheTTL = time.Minute
+
+	// Non-empty source dir + empty target dir under a NON-root parent, plus a
+	// non-empty sibling whose key sorts AFTER the target. The slurp lists from
+	// StartAfter=<target key>, so it re-descends into (and re-locks) the held
+	// parent only when a later-sorting entry under it exists — guaranteed in a
+	// real node_modules, arranged here with "a_"/"z_" names.
+	for _, key := range []string{"dir2/a_src/f1", "dir2/z_sib/f2"} {
+		_, err := s.cloud.PutBlob(&PutBlobInput{
+			Key: key, Body: bytes.NewReader([]byte("x")), Size: PUInt64(1),
+		})
+		t.Assert(err, IsNil)
+	}
+	_, err := s.cloud.PutBlob(&PutBlobInput{
+		Key: "dir2/a_tgt/", Body: bytes.NewReader([]byte{}), Size: PUInt64(0),
+	})
+	t.Assert(err, IsNil)
+
+	parent, err := s.fs.LookupPath("dir2")
+	t.Assert(err, IsNil)
+	_, err = s.fs.LookupPath("dir2/a_src")
+	t.Assert(err, IsNil)
+	tgt, err := s.fs.LookupPath("dir2/a_tgt")
+	t.Assert(err, IsNil)
+
+	// Expire the target's directory cache so isEmptyDir re-lists it from the
+	// cloud (the cold state the live churn kept re-creating). A zero DirTime is
+	// always expired; clearing listMarker/listDone forces the useSlurp path.
+	tgt.mu.Lock()
+	tgt.dir.DirTime = time.Time{}
+	tgt.dir.listMarker = ""
+	tgt.dir.listDone = false
+	tgt.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- parent.Rename("a_src", parent, "a_tgt")
+	}()
+	select {
+	case err = <-done:
+		// The target is empty, so the rename must succeed.
+		t.Assert(err, IsNil)
+	case <-time.After(30 * time.Second):
+		t.Fatalf("Rename deadlocked in the destination emptiness check (listing reload under held locks)")
+	}
+
+	_, err = s.fs.LookupPath("dir2/a_tgt/f1")
+	t.Assert(err, IsNil)
+	_, err = s.fs.LookupPath("dir2/a_src")
+	t.Assert(err, Equals, syscall.ENOENT)
+}
+
 func (s *GoofysTest) TestRenameDir(t *C) {
 	s.fs.flags.StatCacheTTL = 0
 


### PR DESCRIPTION
## Summary

`Rename` can self-deadlock the whole daemon: it calls `toInode.isEmptyDir()` **while holding the parent inode lock(s)**, and on a cold cache `isEmptyDir` loads a directory listing whose `insertSubTree` re-locks ancestor inodes — including the very parent `Rename` already holds. Go mutexes are not reentrant, so the goroutine blocks on itself and every later FUSE op queues behind the held locks forever. The mount is dead until the process is killed.

We hit this in production with an S3-backed `/workspace`: an `npm install` over an existing `node_modules` (its rename-heavy `.pkg-XXXX → pkg` churn) drove a directory into the cold-cache state, and the next operation that renamed a directory wedged the daemon. It reproduces on both `v1.2.1` and current `main`.

## Root cause

`isEmptyDir` builds a `DirHandle` and reads it; on a cold cache that goes through `loadListing → slurpOnce → listObjectsSlurp`, and `slurpOnce` lists from the **root** (it walks `Parent` to the top). `insertSubTree` then re-descends from the root and takes `inode.mu` on each directory on the path back down — which crosses the parent `Rename` is holding.

Goroutine dump from a wedged daemon (`--pprof`, `goroutine?debug=2`), trimmed to the cycle — a single goroutine blocked acquiring a lock it already holds:

```
core.(*Inode).Rename(...)                       <- holds parent.mu
core.(*Inode).isEmptyDir(...)
core.(*DirHandle).ReadDir(...)
core.(*DirHandle).loadListing(...)
core.(*Inode).slurpOnce(...)
core.(*Inode).listObjectsSlurp(...)
core.(*Inode).insertSubTree(...)
core.(*Inode).insertSubTree(...)                <- sync.Mutex.Lock on the held parent — self-deadlock
```

`TestRenameDir` does not catch this because it sets `StatCacheTTL = 0`, which disables the slurp path entirely (`loadListing`'s `useSlurp` condition). The bug only appears with slurp enabled — the production default.

## Fix

Replace the check with `isEmptyDirFast`. It never lists from the root — so there is no ancestor re-lock and no self-deadlock (the deadlock was only ever the *parent* lock being re-taken by the root slurp) — and it reconciles both sides of the cache:

- Any live in-memory child (`inode.dir.Children`, not `ST_DEAD`/`ST_DELETED`) makes the directory non-empty — covering a **local create not yet flushed** to the backend.
- If the directory is fully listed **and that listing has not expired** (`listDone && !expired(DirTime, StatCacheTTL)`), the in-memory children are authoritative and **no backend call is made**.
- Otherwise a **delimited, paged** prefix-scoped `ListBlobs` checks the backend, skipping **locally-deleted** names (`DeletedChildren`) and stopping at the first live child. The delimiter collapses each subtree to one immediate name; paging covers the case where deleted names fill a page, so a live sibling is never missed.

The backend list runs **without `inode.mu` held** — in cluster mode it can be a cross-node RPC, and holding a FUSE inode lock across it would deadlock — and a **re-check of the in-memory children afterward** catches a `Create`/`MkDir` that raced the unlocked list. So unflushed local creates, pending local deletes, and expired listings are all handled, with no root slurp and no lock held across backend I/O.

The now-unused `isEmptyDir` is removed; `RmDir` checks emptiness without holding the parent lock and was never affected.

This is orthogonal to the unmerged `fix-listobjectsslurp-deadlock` branch, which addresses lock inversions in the **seal** phase of `listObjectsSlurp`; this one is the **insert-phase** self-deadlock reached through `isEmptyDir`. Both can land independently.

## Test

`TestRenameDirColdTarget` reproduces the deadlock deterministically. It needs four conditions together, all of which the live workload produced via churn and all set up explicitly:

1. slurp enabled (`StatCacheTTL != 0` — the production default),
2. a parent **below** the root, so the root-down `insertSubTree` walk crosses it,
3. the target directory's cache **expired**, so `isEmptyDir` re-lists instead of answering warm,
4. a non-empty sibling whose key sorts **after** the target — the slurp lists from `StartAfter = <target key>`, so it only re-descends into (and re-locks) the held parent when a later-sorting entry exists (guaranteed in a real `node_modules`; arranged here with `a_`/`z_` names).

A 30s timeout turns the wedge into a test failure rather than a hung suite. Without the fix the test deadlocks and times out; with it, it passes.

## Verification

- New regression test `TestRenameDirColdTarget`: **deadlocks on `main`** (times out), **passes** with the fix.
- Full existing suite (`SAME_PROCESS_MOUNT=1 make run-test`), Lint, XFS Tests, and the randomized Cluster Test: **green** on the fix.
- A load harness (npm version flip-flop over an existing `node_modules` + concurrent readdir + copy/delete churn on a mounted bucket) wedges every unpatched build in under 6 minutes; the fix survives a sustained 25-minute run (~500 install cycles, every liveness probe succeeding) with no wedge.
